### PR TITLE
fix: `hf download` is not the standard HuggingFace CLI command

### DIFF
--- a/docs/DATA.md
+++ b/docs/DATA.md
@@ -41,7 +41,7 @@ Download them from the GEM-X HuggingFace repository and merge the included
 `inputs/` directory into the repository root:
 
 ```bash
-hf download nvidia/GEM-X \
+huggingface-cli download nvidia/GEM-X \
   --include "gem_smpl/missing_hmr4d_support/**" \
   --local-dir .
 


### PR DESCRIPTION
### Problem
fix: `hf download` is not the standard HuggingFace CLI command

### Fix
Replace:
```
hf download nvidia/GEM-X \
  --include "gem_smpl/missing_hmr4d_support/**" \
  --local-dir .
```

with:
```
huggingface-cli download nvidia/GEM-X \
  --include "gem_smpl/missing_hmr4d_support/**" \
  --local-dir .
```

### Files changed
- `docs/DATA.md`